### PR TITLE
Changed logging level of "Setting ROI same" from warn to debug

### DIFF
--- a/org.dawnsci.plotting.draw2d/src/org/dawnsci/plotting/draw2d/swtxy/selection/AbstractRegion.java
+++ b/org.dawnsci.plotting.draw2d/src/org/dawnsci/plotting/draw2d/swtxy/selection/AbstractRegion.java
@@ -143,7 +143,7 @@ public abstract class AbstractRegion<T extends IROI> extends Figure implements I
 		isActive = roi.isPlot(); // set the region isActive flag
 		if (this.roi == roi) {
 			// return; // do not fire event
-			logger.warn("Setting ROI same");
+			logger.debug("Setting ROI same");
 		}
 
 		try {


### PR DESCRIPTION
This logging message is printed repeatedly while dragging a region or
every time live data (with a region on it) is refreshed