### PR TITLE
Dawn 1.8

### DIFF
--- a/org.dawnsci.plotting.feature/feature.xml
+++ b/org.dawnsci.plotting.feature/feature.xml
@@ -88,7 +88,7 @@
          id="com.thoughtworks.xstream"
          download-size="0"
          install-size="0"
-         version="0.0.0"
+         version="1.2.1"
          unpack="false"/>
 
    <plugin

--- a/org.dawnsci.plotting/META-INF/MANIFEST.MF
+++ b/org.dawnsci.plotting/META-INF/MANIFEST.MF
@@ -27,7 +27,7 @@ Export-Package: org.dawnsci.plotting,
  org.dawnsci.plotting.roi,
  org.dawnsci.plotting.util,
  org.dawnsci.plotting.views
-Import-Package: com.thoughtworks.xstream.core.util,
+Import-Package: com.thoughtworks.xstream.core.util;version="[0.0.0,1.3.0)",
  org.dawb.workbench.jmx,
  org.eclipse.core.resources,
  org.eclipse.ui,


### PR DESCRIPTION
SCI-5484 Constrain CompositeClassLoader version used by plotting system

- Constrain the version of the XStream class loader to allow third party
contributors to add their own version without disabling plotting.
- plotting system using v1.2.1 Constrain to < v1.3