### PR TITLE
FileViewer: improve performance

### DIFF
--- a/org.dawnsci.fileviewer/META-INF/MANIFEST.MF
+++ b/org.dawnsci.fileviewer/META-INF/MANIFEST.MF
@@ -20,7 +20,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.dawnsci.slicing.api,
  org.apache.commons.io;bundle-version="2.4.0",
  org.eclipse.dawnsci.analysis.api,
- org.eclipse.january
+ org.eclipse.january,
+ org.apache.commons.lang
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: javax.inject;version="1.0.0",
  org.slf4j;version="1.7.6",

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/FileViewer.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/FileViewer.java
@@ -17,7 +17,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.dawb.common.ui.util.EclipseUtils;
-import org.dawnsci.fileviewer.Utils.SortType;
 import org.dawnsci.fileviewer.handlers.ConvertHandler;
 import org.dawnsci.fileviewer.handlers.LayoutHandler;
 import org.dawnsci.fileviewer.handlers.OpenHandler;
@@ -26,7 +25,6 @@ import org.dawnsci.fileviewer.handlers.PreferencesHandler;
 import org.dawnsci.fileviewer.handlers.RefreshHandler;
 import org.dawnsci.fileviewer.table.FileTableContent;
 import org.dawnsci.fileviewer.table.FileTableExplorer;
-import org.dawnsci.fileviewer.table.FileTableViewerComparator;
 import org.dawnsci.fileviewer.table.RetrieveFileListJob;
 import org.dawnsci.fileviewer.tree.FileTreeExplorer;
 import org.dawnsci.fileviewer.tree.TreeUtils;

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/FileViewer.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/FileViewer.java
@@ -13,6 +13,7 @@ package org.dawnsci.fileviewer;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.dawb.common.ui.util.EclipseUtils;
@@ -23,6 +24,7 @@ import org.dawnsci.fileviewer.handlers.OpenHandler;
 import org.dawnsci.fileviewer.handlers.ParentHandler;
 import org.dawnsci.fileviewer.handlers.PreferencesHandler;
 import org.dawnsci.fileviewer.handlers.RefreshHandler;
+import org.dawnsci.fileviewer.table.FileTableContent;
 import org.dawnsci.fileviewer.table.FileTableExplorer;
 import org.dawnsci.fileviewer.table.FileTableViewerComparator;
 import org.dawnsci.fileviewer.table.RetrieveFileListJob;
@@ -334,7 +336,7 @@ public class FileViewer {
 				} else {
 					String directory = text.substring(0, text.lastIndexOf(File.separator));
 					// open file in editor
-					doDefaultFileAction(new File[] {new File(text)});
+					doDefaultFileAction(new FileTableContent[] {new FileTableContent(new File(text))});
 					// open directory
 					notifySelectedDirectory(new File(directory));
 				}
@@ -435,7 +437,7 @@ public class FileViewer {
 	 *            the files that were selected, null or empty array indicates no
 	 *            active selection
 	 */
-	public void notifySelectedFiles(File[] files) {
+	public void notifySelectedFiles(FileTableContent[] files) {
 		/*
 		 * Details: Update the details that are visible on screen.
 		 */
@@ -444,7 +446,7 @@ public class FileViewer {
 					new Object[] { new Integer(files.length) }));
 			long fileSize = 0L;
 			for (int i = 0; i < files.length; ++i) {
-				fileSize += files[i].length();
+				fileSize += files[i].getFile().length();
 			}
 			diskSpaceLabel.setText(Utils.getResourceString("details.FileSize.text", new Object[] { new Long(fileSize) }));
 		} else {
@@ -455,13 +457,12 @@ public class FileViewer {
 				if (retrieveDirJob != null && retrieveDirJob.getState() == Job.RUNNING) {
 					retrieveDirJob.cancel();
 				}
-				retrieveDirJob = new RetrieveFileListJob(currentDirectory, tableExplo.getSortType(), tableExplo.getSortDirection(), tableExplo.getFilter(), tableExplo.getUseRegex());
+				retrieveDirJob = new RetrieveFileListJob(currentDirectory, tableExplo.getSortType(), tableExplo.getSortDirection(), tableExplo.getFilter(), tableExplo.getUseRegex(), true);
 //				retrieveDirJob.setThread(workerThread);
 				retrieveDirJob.addJobChangeListener(new JobChangeAdapter() {
 					@Override
 					public void done(IJobChangeEvent event) {
-						File[] dirList = retrieveDirJob.getDirList();
-						int numObjects = dirList == null ? 0 : dirList.length;
+						int numObjects = retrieveDirJob.getDirListCount();
 						Display.getDefault().syncExec(new Runnable() {
 							public void run() {
 								numObjectsLabel.setText(Utils.getResourceString("details.DirNumberOfObjects.text", new Object[] { new Integer(numObjects) }));
@@ -590,11 +591,11 @@ public class FileViewer {
 	 * @param files
 	 *            the array of files to process
 	 */
-	public void doDefaultFileAction(File[] files) {
+	public void doDefaultFileAction(FileTableContent[] files) {
 		// only uses the 1st file (for now)
 		if (files.length == 0)
 			return;
-		final File file = files[0];
+		final File file = files[0].getFile();
 
 		if (file.isDirectory()) {
 			notifySelectedDirectory(file);
@@ -874,7 +875,7 @@ public class FileViewer {
 				}
 			}
 			File[] roots = list.toArray(new File[list.size()]);
-			Utils.sortFiles(roots, SortType.NAME, FileTableViewerComparator.ASC);
+			Arrays.sort(roots);
 			return roots;
 		}
 		File root = new File(File.separator);

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/Utils.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/Utils.java
@@ -20,12 +20,12 @@ import java.util.Iterator;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.dawb.common.ui.util.EclipseUtils;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
@@ -39,7 +39,6 @@ import uk.ac.diamond.sda.navigator.views.IOpenFileAction;
 public class Utils {
 
 	private static ResourceBundle resourceBundle = ResourceBundle.getBundle("file_viewer");
-	private static final ScanCmdJob job = new ScanCmdJob();
 
 	public enum SortType {
 		NAME,
@@ -49,6 +48,12 @@ public class Utils {
 		SCAN;
 	}
 
+	public enum SortDirection {
+		ASC,
+		NONE,
+		DESC;
+	}
+	
 	/**
 	 * Returns a string from the resource bundle. We don't want to crash because
 	 * of a missing String. Returns the key if not found.
@@ -178,8 +183,7 @@ public class Utils {
 		protected IStatus run(IProgressMonitor monitor) {
 			if (file.isFile()) {
 				String extension = getFileExtension(file);
-				if (extension.equals("nxs") || extension.equals("hdf") || extension.equals("h5")
-						|| extension.equals("hdf5") || extension.equals("dat")) {
+				if (ArrayUtils.contains(new String[]{"nxs", "hdf", "h5", "hdf5", "dat"}, extension)) {
 					String filePath = file.getAbsolutePath();
 					try {
 						ILoaderService loader = ServiceHolder.getLoaderService();
@@ -189,7 +193,7 @@ public class Utils {
 						for (Iterator<String> iterator = metanames.iterator(); iterator.hasNext();) {
 							if (monitor.isCanceled())
 								return Status.OK_STATUS;
-							String string = (String) iterator.next();
+							String string = iterator.next();
 							if (string.contains("scan_command")) {
 								Serializable value = meta.getMetaValue(string);
 								scanCmd = (String) value;
@@ -232,8 +236,7 @@ public class Utils {
 						String string = (String) iterator.next();
 						if (string.contains("scan_command")) {
 							Serializable value = meta.getMetaValue(string);
-							String scanCmd = (String) value;
-							return scanCmd;
+							return (String) value;
 						}
 					}
 				} catch (Exception e) {

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/Utils.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/Utils.java
@@ -12,7 +12,6 @@
 package org.dawnsci.fileviewer;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.io.Serializable;
 import java.text.MessageFormat;
 import java.util.Collection;
@@ -20,17 +19,16 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 
-import org.apache.commons.io.filefilter.RegexFileFilter;
-import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.dawb.common.ui.util.EclipseUtils;
-import org.dawnsci.fileviewer.table.FileTableViewerComparator;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.dawnsci.analysis.api.io.IDataHolder;
 import org.eclipse.dawnsci.analysis.api.io.ILoaderService;
 import org.eclipse.january.metadata.IMetadata;
@@ -41,6 +39,7 @@ import uk.ac.diamond.sda.navigator.views.IOpenFileAction;
 public class Utils {
 
 	private static ResourceBundle resourceBundle = ResourceBundle.getBundle("file_viewer");
+	private static final ScanCmdJob job = new ScanCmdJob();
 
 	public enum SortType {
 		NAME,
@@ -76,150 +75,6 @@ public class Utils {
 		} catch (NullPointerException e) {
 			return "!" + key + "!";
 		}
-	}
-
-	/**
-	 * Sorts files lexicographically by name.
-	 * 
-	 * @param files
-	 *            the array of Files to be sorted
-	 */
-	public static void sortFiles(File[] files, SortType sortType, int direction) {
-		/* Very lazy merge sort algorithm */
-		sortBlock(files, 0, files.length - 1, new File[files.length], sortType, direction, null);
-	}
-
-	/**
-	 * Sorts files lexicographically by name.
-	 * 
-	 * @param files
-	 *            the array of Files to be sorted
-	 */
-	public static void sortFiles(File[] files, SortType sortType, int direction, IProgressMonitor monitor) {
-		/* Very lazy merge sort algorithm */
-		sortBlock(files, 0, files.length - 1, new File[files.length], sortType, direction, monitor);
-	}
-
-	private static void sortBlock(File[] files, int start, int end, File[] mergeTemp, SortType sortType, int direction, IProgressMonitor monitor) {
-		final int length = end - start + 1;
-		if (length < 8) {
-			for (int i = end; i > start; --i) {
-				for (int j = end; j > start; --j) {
-					if (compareFiles(files[j - 1], files[j], sortType, direction) > 0) {
-						final File temp = files[j];
-						files[j] = files[j - 1];
-						files[j - 1] = temp;
-						if (monitor != null && monitor.isCanceled())
-							return;
-					}
-				}
-			}
-			return;
-		}
-		final int mid = (start + end) / 2;
-		sortBlock(files, start, mid, mergeTemp, sortType, direction, monitor);
-		sortBlock(files, mid + 1, end, mergeTemp, sortType, direction, monitor);
-		int x = start;
-		int y = mid + 1;
-		for (int i = 0; i < length; ++i) {
-			if ((x > mid) || ((y <= end) && compareFiles(files[x], files[y], sortType, direction) > 0)) {
-				mergeTemp[i] = files[y++];
-			} else {
-				mergeTemp[i] = files[x++];
-			}
-			if (monitor != null && monitor.isCanceled())
-				return;
-		}
-		for (int i = 0; i < length; ++i)
-			files[i + start] = mergeTemp[i];
-	}
-
-	public static int compareFiles(File a, File b, SortType sortType, int direction) {
-		// boolean aIsDir = a.isDirectory();
-		// boolean bIsDir = b.isDirectory();
-		// if (aIsDir && ! bIsDir) return -1;
-		// if (bIsDir && ! aIsDir) return 1;
-
-		// sort case-sensitive files in a case-insensitive manner
-		int compare = 0;
-		switch (sortType) {
-		case NAME:
-			compare = a.getName().compareToIgnoreCase(b.getName());
-			if (compare == 0)
-				compare = a.getName().compareTo(b.getName());
-			break;
-		case SIZE:
-			long sizea = a.length(), sizeb = b.length();
-			compare = sizea < sizeb ? -1 : 1;
-			break;
-		case TYPE:
-			String typea = getFileTypeString(a), typeb = getFileTypeString(b);
-			compare = typea.compareToIgnoreCase(typeb);
-			if (compare == 0)
-				compare = typea.compareTo(typeb);
-			break;
-		case DATE:
-			Date date1 = new Date(a.lastModified());
-			Date date2 = new Date(b.lastModified());
-			compare = date1.compareTo(date2);
-			break;
-		case SCAN:
-			String scana = getFileScanCmdString(a), scanb = getFileScanCmdString(b);
-			compare = scana.compareToIgnoreCase(scanb);
-			if (compare == 0)
-				compare = scana.compareTo(scanb);
-			break;
-		default:
-			return 0;
-		}
-		if (FileTableViewerComparator.DESC == direction)
-			return (-1 * compare);
-		return compare;
-	}
-
-	/**
-	 * Gets a directory listing
-	 * 
-	 * @param file
-	 *            the directory to be listed
-	 * @param sort
-	 *            the sorting type
-	 * @return an array of files this directory contains, may be empty but not
-	 *         null
-	 */
-	public static File[] getDirectoryList(File file, SortType sortType, int direction, String filter, boolean useRegex) {
-		return getDirectoryList(file, sortType, direction, filter, useRegex, null);
-	}
-
-	/**
-	 * Gets a directory listing
-	 * 
-	 * @param file
-	 *            the directory to be listed
-	 * @param sort
-	 *            the sorting type
-	 * @return an array of files this directory contains, may be empty but not
-	 *         null
-	 */
-	public static File[] getDirectoryList(File file, SortType sortType, int direction, String filter, boolean useRegex, IProgressMonitor monitor) {
-		File[] list = null;
-		if (filter == null || filter.equals("*") || Pattern.matches("^\\s*$", filter)) {
-			list = file.listFiles();
-		}
-		else if (useRegex) {
-			try {
-				list = file.listFiles((FileFilter) new RegexFileFilter(filter));
-			} catch (PatternSyntaxException e) {
-				list = null;
-			}
-		}
-		else {
-			list = file.listFiles((FileFilter) new WildcardFileFilter(filter));
-		}
-		if (list == null)
-			return new File[0];
-		sortFiles(list, sortType, direction, monitor);
-		return list;
 	}
 
 	/**
@@ -306,6 +161,54 @@ public class Utils {
 		return FileViewerConstants.dateFormat.format(new Date(file.lastModified()));
 	}
 
+	static class ScanCmdJob extends Job {
+		private File file;
+		private String scanCmd = "";
+		
+		public ScanCmdJob() {
+			super("ScanCmdJob");
+		}
+
+		public void setFile(File file) {
+			this.file = file;
+			this.scanCmd = "";
+		}
+		
+		@Override
+		protected IStatus run(IProgressMonitor monitor) {
+			if (file.isFile()) {
+				String extension = getFileExtension(file);
+				if (extension.equals("nxs") || extension.equals("hdf") || extension.equals("h5")
+						|| extension.equals("hdf5") || extension.equals("dat")) {
+					String filePath = file.getAbsolutePath();
+					try {
+						ILoaderService loader = ServiceHolder.getLoaderService();
+						IDataHolder dh = loader.getData(filePath, null);
+						IMetadata meta = dh.getMetadata();
+						Collection<String> metanames = meta.getMetaNames();
+						for (Iterator<String> iterator = metanames.iterator(); iterator.hasNext();) {
+							if (monitor.isCanceled())
+								return Status.OK_STATUS;
+							String string = (String) iterator.next();
+							if (string.contains("scan_command")) {
+								Serializable value = meta.getMetaValue(string);
+								scanCmd = (String) value;
+								return Status.OK_STATUS;
+							}
+						}
+					} catch (Exception e) {
+						return Status.OK_STATUS;
+					}
+				}
+			}
+			return Status.OK_STATUS;
+		}
+		
+		public String getScanCmd() {
+			return scanCmd;
+		}
+	}
+	
 	/**
 	 * Get the Scan Command if file contains one
 	 * 
@@ -320,18 +223,21 @@ public class Utils {
 				String filePath = file.getAbsolutePath();
 				try {
 					ILoaderService loader = ServiceHolder.getLoaderService();
-					IDataHolder dh = loader.getData(filePath, null);
+					IDataHolder dh = loader.getData(filePath, true, null);
 					IMetadata meta = dh.getMetadata();
 					Collection<String> metanames = meta.getMetaNames();
 					for (Iterator<String> iterator = metanames.iterator(); iterator.hasNext();) {
+						if (Thread.currentThread().isInterrupted())
+							return "";
 						String string = (String) iterator.next();
 						if (string.contains("scan_command")) {
 							Serializable value = meta.getMetaValue(string);
-							return (String) value;
+							String scanCmd = (String) value;
+							return scanCmd;
 						}
 					}
 				} catch (Exception e) {
-				
+					return "";
 				}
 			}
 		}

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/handlers/ConvertHandler.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/handlers/ConvertHandler.java
@@ -1,10 +1,14 @@
 
 package org.dawnsci.fileviewer.handlers;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.inject.Inject;
 
 import org.dawnsci.conversion.ui.ConvertWizard;
 import org.dawnsci.fileviewer.FileViewer;
+import org.dawnsci.fileviewer.table.FileTableContent;
 import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.wizard.WizardDialog;
@@ -25,7 +29,17 @@ public class ConvertHandler {
 	public void execute() {
 		ConvertWizard cwizard = new ConvertWizard();
 		IStructuredSelection sel = fileviewer.getSelections();
-		cwizard.setSelectionOverride(sel.toList());
+		@SuppressWarnings("rawtypes")
+		List selFiles;
+		if (sel.getFirstElement() instanceof FileTableContent) {
+			selFiles = new ArrayList<>();
+			for (Object selElement : sel.toArray()) {
+				selFiles.add(((FileTableContent)selElement).getFile());
+			}
+		} else {
+			selFiles = sel.toList();
+		}
+		cwizard.setSelectionOverride(selFiles);
 		WizardDialog dialog = new WizardDialog(Display.getDefault().getActiveShell(), cwizard);
 		dialog.setPageSize(new Point(400, 450));
 		dialog.create();

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableColumnLabelProvider.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableColumnLabelProvider.java
@@ -10,7 +10,9 @@ package org.dawnsci.fileviewer.table;
 
 import java.io.File;
 
+import org.dawnsci.fileviewer.Activator;
 import org.dawnsci.fileviewer.FileViewer;
+import org.dawnsci.fileviewer.FileViewerConstants;
 import org.dawnsci.fileviewer.Utils;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.swt.graphics.Image;
@@ -69,7 +71,9 @@ public class FileTableColumnLabelProvider extends ColumnLabelProvider {
 		case 3:
 			return Utils.getFileDateString(file);
 		case 4:
-			return Utils.getFileScanCmdString(file);
+			if (Activator.getDefault().getPreferenceStore().getBoolean(FileViewerConstants.SHOW_SCANCMD_COLUMN))
+				return Utils.getFileScanCmdString(file);
+			return null;
 		default:
 			break;
 		}

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableColumnLabelProvider.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableColumnLabelProvider.java
@@ -10,10 +10,7 @@ package org.dawnsci.fileviewer.table;
 
 import java.io.File;
 
-import org.dawnsci.fileviewer.Activator;
 import org.dawnsci.fileviewer.FileViewer;
-import org.dawnsci.fileviewer.FileViewerConstants;
-import org.dawnsci.fileviewer.Utils;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.program.Program;
@@ -31,9 +28,10 @@ public class FileTableColumnLabelProvider extends ColumnLabelProvider {
 	@Override
 	public Image getImage(Object element) {
 		Image iconImage = null;
-		if (element instanceof File && columnIndex == 0) {
-			File file = (File) element;
-			String nameString = file.getName();
+		if (element instanceof FileTableContent && columnIndex == 0) {
+			FileTableContent content = (FileTableContent) element;
+			File file = content.getFile();
+			String nameString = content.getFileName();
 			if (file.isDirectory()) {
 				iconImage = viewer.getIconCache().stockImages[viewer.getIconCache().iconClosedFolder];
 			} else {
@@ -60,20 +58,18 @@ public class FileTableColumnLabelProvider extends ColumnLabelProvider {
 
 	@Override
 	public String getText(Object element) {
-		File file = (File) element;
+		FileTableContent content = (FileTableContent) element;
 		switch (this.columnIndex) {
 		case 0:
-			return file.getName();
+			return content.getFileName();
 		case 1:
-			return Utils.getFileSizeString(file, viewer.isSizeSIUnit());
+			return viewer.isSizeSIUnit() ? content.getFileSizeSI() : content.getFileSizeReg();
 		case 2:
-			return Utils.getFileTypeString(file);
+			return content.getFileType();
 		case 3:
-			return Utils.getFileDateString(file);
+			return content.getFileDate();
 		case 4:
-			if (Activator.getDefault().getPreferenceStore().getBoolean(FileViewerConstants.SHOW_SCANCMD_COLUMN))
-				return Utils.getFileScanCmdString(file);
-			return null;
+			return content.getFileScanCmd();
 		default:
 			break;
 		}

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableContent.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableContent.java
@@ -1,0 +1,82 @@
+package org.dawnsci.fileviewer.table;
+
+import java.io.File;
+
+import org.dawnsci.fileviewer.Utils;
+
+public class FileTableContent {
+	private final File file;
+	private final String fileName;
+	private final String fileSizeSI;
+	private final String fileSizeReg;
+	private final String fileType;
+	private final String fileDate;
+	private String fileScanCmd = "";
+	
+	static class FileScanCmdThread extends Thread {
+		private final File file;
+		private String cmd = "";
+		
+		public FileScanCmdThread(File file) {
+			this.file = file;
+		}
+		
+		@Override
+		public void run() {
+			cmd = Utils.getFileScanCmdString(file);
+		}
+	
+		public String getFileScanCmd() {
+			return cmd;
+		}
+	}
+	
+	public FileTableContent(File file) {
+		this.file = file;
+		fileName = file.getName();
+		fileSizeSI = Utils.getFileSizeString(file, true);
+		fileSizeReg = Utils.getFileSizeString(file, false);
+		fileType = Utils.getFileTypeString(file);
+		fileDate = Utils.getFileDateString(file);
+	
+		FileScanCmdThread thread = new FileScanCmdThread(file);
+		thread.start();
+		try {
+			thread.join(100);
+			fileScanCmd = thread.getFileScanCmd();
+		} catch (InterruptedException e) {
+		}
+		// Since I cannot cancel the HDF5 loader routine while it is running,
+		// and since it blocks all other invocations of this loader,
+		// I see no alternative other than killing this thread
+		thread.stop();
+	}
+
+	public File getFile() {
+		return file;
+	}
+
+	public String getFileName() {
+		return fileName;
+	}
+
+	public String getFileSizeSI() {
+		return fileSizeSI;
+	}
+
+	public String getFileSizeReg() {
+		return fileSizeReg;
+	}
+
+	public String getFileType() {
+		return fileType;
+	}
+
+	public String getFileDate() {
+		return fileDate;
+	}
+
+	public String getFileScanCmd() {
+		return fileScanCmd;
+	}
+}

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableContent.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableContent.java
@@ -46,7 +46,7 @@ public class FileTableContent {
 		FileScanCmdThread thread = new FileScanCmdThread(file);
 		thread.start();
 		try {
-			thread.join(100);
+			thread.join(200);
 			fileScanCmd = thread.getFileScanCmd();
 		} catch (InterruptedException e) {
 		}

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableContent.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableContent.java
@@ -3,6 +3,8 @@ package org.dawnsci.fileviewer.table;
 import java.io.File;
 
 import org.dawnsci.fileviewer.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FileTableContent {
 	private final File file;
@@ -12,6 +14,8 @@ public class FileTableContent {
 	private final String fileType;
 	private final String fileDate;
 	private String fileScanCmd = "";
+	
+	private final static Logger logger = LoggerFactory.getLogger(FileTableContent.class);
 	
 	static class FileScanCmdThread extends Thread {
 		private final File file;
@@ -49,7 +53,10 @@ public class FileTableContent {
 		// Since I cannot cancel the HDF5 loader routine while it is running,
 		// and since it blocks all other invocations of this loader,
 		// I see no alternative other than killing this thread
-		thread.stop();
+		if (thread.isAlive()) {
+			logger.warn("Killing thread for {}", file.getName());
+			thread.stop();
+		}
 	}
 
 	public File getFile() {

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableContent.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableContent.java
@@ -15,7 +15,7 @@ public class FileTableContent {
 	private final String fileDate;
 	private String fileScanCmd = "";
 	
-	private final static Logger logger = LoggerFactory.getLogger(FileTableContent.class);
+	private static final Logger logger = LoggerFactory.getLogger(FileTableContent.class);
 	
 	static class FileScanCmdThread extends Thread {
 		private final File file;

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableContentProvider.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableContentProvider.java
@@ -8,8 +8,6 @@
  */
 package org.dawnsci.fileviewer.table;
 
-import java.io.File;
-
 import org.eclipse.jface.viewers.ILazyContentProvider;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.Viewer;
@@ -17,7 +15,7 @@ import org.eclipse.jface.viewers.Viewer;
 public class FileTableContentProvider implements ILazyContentProvider {
 
 	private TableViewer viewer;
-	private File[] input;
+	private FileTableContent[] input;
 
 	public FileTableContentProvider(TableViewer viewer) {
 		this.viewer = viewer;
@@ -27,7 +25,7 @@ public class FileTableContentProvider implements ILazyContentProvider {
 	}
 
 	public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
-		this.input = (File[]) newInput;
+		this.input = (FileTableContent[]) newInput;
 	}
 
 	public void updateElement(int index) {

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableExplorer.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableExplorer.java
@@ -19,6 +19,7 @@ import org.dawnsci.fileviewer.FileViewer;
 import org.dawnsci.fileviewer.FileViewerConstants;
 import org.dawnsci.fileviewer.Utils;
 import org.dawnsci.fileviewer.Utils.SortType;
+import org.dawnsci.fileviewer.Utils.SortDirection;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.jobs.JobChangeAdapter;
@@ -90,7 +91,7 @@ public class FileTableExplorer {
 	// Sort type
 	private volatile SortType sortType = SortType.NAME;
 	// Sort direction
-	private volatile int sortDirection = 0;
+	private volatile SortDirection sortDirection = SortDirection.NONE;
 
 	/*
 	 * Job used to retrieve the list of file/directory in a folder
@@ -392,7 +393,7 @@ public class FileTableExplorer {
 	 * @param force
 	 *            if true causes a refresh even if the data is the same
 	 */
-	public void workerUpdate(File dir, boolean force, SortType type, int direction) {
+	public void workerUpdate(File dir, boolean force, SortType type, SortDirection direction) {
 		if (dir == null)
 			return;
 		if ((!force) && (workerNextDir != null) && (workerNextDir.equals(dir)))
@@ -443,7 +444,7 @@ public class FileTableExplorer {
 	/**
 	 * Updates the table's contents
 	 */
-	private void workerExecute(SortType sortType, int direction, String filter, boolean useRegex) {
+	private void workerExecute(SortType sortType, SortDirection direction, String filter, boolean useRegex) {
 		// Clear existing information
 		Display.getDefault().syncExec(new Runnable() {
 			@Override
@@ -493,7 +494,7 @@ public class FileTableExplorer {
 		return sortType;
 	}
 
-	public int getSortDirection() {
+	public SortDirection getSortDirection() {
 		return sortDirection;
 	}
 

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableExplorer.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableExplorer.java
@@ -238,9 +238,9 @@ public class FileTableExplorer {
 	 * Returns the selected files in the table
 	 * @return
 	 */
-	public File[] getSelectedFiles() {
+	public FileTableContent[] getSelectedFiles() {
 		StructuredSelection selection = (StructuredSelection) tviewer.getSelection();
-		return Arrays.copyOf(selection.toArray(), selection.size(), File[].class);
+		return Arrays.copyOf(selection.toArray(), selection.size(), FileTableContent[].class);
 	}
 
 	private void createColumns(int[] widths) {
@@ -294,8 +294,8 @@ public class FileTableExplorer {
 					return;
 				sourceNames = new String[dndSelection.length];
 				for (int i = 0; i < dndSelection.length; i++) {
-					File file = (File) dndSelection[i].getData();
-					sourceNames[i] = file.getAbsolutePath();
+					FileTableContent content = (FileTableContent) dndSelection[i].getData();
+					sourceNames[i] = content.getFile().getAbsolutePath();
 				}
 				event.data = sourceNames;
 			}
@@ -456,12 +456,12 @@ public class FileTableExplorer {
 				if (retrieveDirJob != null && retrieveDirJob.getState() == Job.RUNNING) {
 					retrieveDirJob.cancel();
 				}
-				retrieveDirJob = new RetrieveFileListJob(workerStateDir, sortType, direction, filter, useRegex);
+				retrieveDirJob = new RetrieveFileListJob(workerStateDir, sortType, direction, filter, useRegex, false);
 				retrieveDirJob.setThread(workerThread);
 				retrieveDirJob.addJobChangeListener(new JobChangeAdapter() {
 					@Override
 					public void done(IJobChangeEvent event) {
-						File[] dirList = retrieveDirJob.getDirList();
+						FileTableContent[] dirList = retrieveDirJob.getDirList();
 						Display.getDefault().syncExec(new Runnable() {
 							public void run() {
 								if (tviewer != null && dirList != null) {

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableUtils.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableUtils.java
@@ -3,7 +3,6 @@ package org.dawnsci.fileviewer.table;
 import java.io.File;
 import java.io.FileFilter;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -13,7 +12,6 @@ import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.dawnsci.fileviewer.Utils;
 import org.dawnsci.fileviewer.Utils.SortType;
 import org.dawnsci.fileviewer.Utils.SortDirection;
-import org.eclipse.core.runtime.IProgressMonitor;
 
 public class FileTableUtils {
 	
@@ -79,21 +77,7 @@ public class FileTableUtils {
 	 * @return an array of files this directory contains, may be empty but not
 	 *         null
 	 */
-	public static FileTableContent[] getDirectoryList(File file, SortType sortType, SortDirection sortDirection, String filter, boolean useRegex) {
-		return getDirectoryList(file, sortType, sortDirection, filter, useRegex, null);
-	}
-
-	/**
-	 * Gets a directory listing
-	 * 
-	 * @param file
-	 *            the directory to be listed
-	 * @param sort
-	 *            the sorting type
-	 * @return an array of files this directory contains, may be empty but not
-	 *         null
-	 */
-	public static FileTableContent[] getDirectoryList(File file, SortType sortType, SortDirection sortDirection, String filter, boolean useRegex, IProgressMonitor monitor) {
+	public static FileTableContent[] getDirectoryList(File file, SortType sortType, SortDirection sortDirection, String filter, boolean useRegex ) {
 		File[] list = null;
 		if (filter == null || "*".equals(filter) || Pattern.matches("^\\s*$", filter)) {
 			list = file.listFiles();
@@ -111,13 +95,7 @@ public class FileTableUtils {
 		if (list == null || list.length == 0)
 			return new FileTableContent[0];
 		FileTableContent[] contentList = createFileTableContentListFromFiles(list);
-		Arrays.sort(contentList, new Comparator<FileTableContent>() {
-
-			@Override
-			public int compare(FileTableContent o1, FileTableContent o2) {
-				return compareFiles(o1, o2, sortType, sortDirection);
-			}
-		});
+		Arrays.sort(contentList, (a, b) -> compareFiles(a, b, sortType, sortDirection));
 		return contentList;
 	}
 

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableUtils.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableUtils.java
@@ -1,0 +1,199 @@
+package org.dawnsci.fileviewer.table;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.util.Date;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Stream;
+
+import org.apache.commons.io.filefilter.RegexFileFilter;
+import org.apache.commons.io.filefilter.WildcardFileFilter;
+import org.dawnsci.fileviewer.Utils.SortType;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+public class FileTableUtils {
+
+	/**
+	 * Sorts files lexicographically by name.
+	 * 
+	 * @param files
+	 *            the array of Files to be sorted
+	 */
+	public static void sortFiles(FileTableContent[] files, SortType sortType, int direction) {
+		/* Very lazy merge sort algorithm */
+		sortBlock(files, 0, files.length - 1, new FileTableContent[files.length], sortType, direction, null);
+	}
+
+	/**
+	 * Sorts files lexicographically by name.
+	 * 
+	 * @param files
+	 *            the array of Files to be sorted
+	 */
+	public static void sortFiles(FileTableContent[] files, SortType sortType, int direction, IProgressMonitor monitor) {
+		/* Very lazy merge sort algorithm */
+		sortBlock(files, 0, files.length - 1, new FileTableContent[files.length], sortType, direction, monitor);
+	}
+
+	private static void sortBlock(FileTableContent[] files, int start, int end, FileTableContent[] mergeTemp, SortType sortType, int direction, IProgressMonitor monitor) {
+		final int length = end - start + 1;
+		if (length < 8) {
+			for (int i = end; i > start; --i) {
+				for (int j = end; j > start; --j) {
+					if (compareFiles(files[j - 1], files[j], sortType, direction) > 0) {
+						final FileTableContent temp = files[j];
+						files[j] = files[j - 1];
+						files[j - 1] = temp;
+						if (monitor != null && monitor.isCanceled())
+							return;
+					}
+				}
+			}
+			return;
+		}
+		final int mid = (start + end) / 2;
+		sortBlock(files, start, mid, mergeTemp, sortType, direction, monitor);
+		sortBlock(files, mid + 1, end, mergeTemp, sortType, direction, monitor);
+		int x = start;
+		int y = mid + 1;
+		for (int i = 0; i < length; ++i) {
+			if ((x > mid) || ((y <= end) && compareFiles(files[x], files[y], sortType, direction) > 0)) {
+				mergeTemp[i] = files[y++];
+			} else {
+				mergeTemp[i] = files[x++];
+			}
+			if (monitor != null && monitor.isCanceled())
+				return;
+		}
+		for (int i = 0; i < length; ++i)
+			files[i + start] = mergeTemp[i];
+	}
+
+	public static int compareFiles(FileTableContent a, FileTableContent b, SortType sortType, int direction) {
+		// boolean aIsDir = a.isDirectory();
+		// boolean bIsDir = b.isDirectory();
+		// if (aIsDir && ! bIsDir) return -1;
+		// if (bIsDir && ! aIsDir) return 1;
+
+		// sort case-sensitive files in a case-insensitive manner
+		int compare = 0;
+		switch (sortType) {
+		case NAME:
+			compare = a.getFileName().compareToIgnoreCase(b.getFileName());
+			if (compare == 0)
+				compare = a.getFileName().compareTo(b.getFileName());
+			break;
+		case SIZE:
+			long sizea = a.getFile().length(), sizeb = b.getFile().length();
+			compare = sizea < sizeb ? -1 : 1;
+			break;
+		case TYPE:
+			String typea = a.getFileType(), typeb = b.getFileType();
+			compare = typea.compareToIgnoreCase(typeb);
+			if (compare == 0)
+				compare = typea.compareTo(typeb);
+			break;
+		case DATE:
+			Date date1 = new Date(a.getFile().lastModified());
+			Date date2 = new Date(b.getFile().lastModified());
+			compare = date1.compareTo(date2);
+			break;
+		case SCAN:
+			String scana = a.getFileScanCmd(), scanb = b.getFileScanCmd();
+			compare = scana.compareToIgnoreCase(scanb);
+			if (compare == 0)
+				compare = scana.compareTo(scanb);
+			break;
+		default:
+			return 0;
+		}
+		if (FileTableViewerComparator.DESC == direction)
+			return (-1 * compare);
+		return compare;
+	}
+
+	/**
+	 * Gets a directory listing
+	 * 
+	 * @param file
+	 *            the directory to be listed
+	 * @param sort
+	 *            the sorting type
+	 * @return an array of files this directory contains, may be empty but not
+	 *         null
+	 */
+	public static FileTableContent[] getDirectoryList(File file, SortType sortType, int direction, String filter, boolean useRegex) {
+		return getDirectoryList(file, sortType, direction, filter, useRegex, null);
+	}
+
+	/**
+	 * Gets a directory listing
+	 * 
+	 * @param file
+	 *            the directory to be listed
+	 * @param sort
+	 *            the sorting type
+	 * @return an array of files this directory contains, may be empty but not
+	 *         null
+	 */
+	public static FileTableContent[] getDirectoryList(File file, SortType sortType, int direction, String filter, boolean useRegex, IProgressMonitor monitor) {
+		System.out.println("getting directory list for " + file.getName());
+		File[] list = null;
+		if (filter == null || filter.equals("*") || Pattern.matches("^\\s*$", filter)) {
+			list = file.listFiles();
+		}
+		else if (useRegex) {
+			try {
+				list = file.listFiles((FileFilter) new RegexFileFilter(filter));
+			} catch (PatternSyntaxException e) {
+				list = null;
+			}
+		}
+		else {
+			list = file.listFiles((FileFilter) new WildcardFileFilter(filter));
+		}
+		if (list == null || list.length == 0)
+			return new FileTableContent[0];
+		FileTableContent[] contentList = createFileTableContentListFromFiles(list);
+		sortFiles(contentList, sortType, direction, monitor);
+		return contentList;
+	}
+
+	public static int getDirectoryListCount(File file, SortType sortType, int direction, String filter, boolean useRegex, IProgressMonitor monitor) {
+		System.out.println("getting directory list count for " + file.getName());
+		File[] list = null;
+		if (filter == null || filter.equals("*") || Pattern.matches("^\\s*$", filter)) {
+			list = file.listFiles();
+		}
+		else if (useRegex) {
+			try {
+				list = file.listFiles((FileFilter) new RegexFileFilter(filter));
+			} catch (PatternSyntaxException e) {
+				list = null;
+			}
+		}
+		else {
+			list = file.listFiles((FileFilter) new WildcardFileFilter(filter));
+		}
+		if (list == null)
+			return 0; 
+		return list.length;
+	}
+
+	private static FileTableContent[] createFileTableContentListFromFiles(File[] fileList) {
+		if (fileList == null || fileList.length == 0)
+			return null;
+		
+		//FileTableContent[] rv = Stream.of(fileList).map(FileTableContent::new).toArray(FileTableContent[]::new);
+		FileTableContent[] rv = new FileTableContent[fileList.length];
+		for (int i = 0 ; i < fileList.length ; i++)
+			rv[i] = new FileTableContent(fileList[i]);
+		
+		
+		return rv;
+	}
+	
+}

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableUtils.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableUtils.java
@@ -140,7 +140,6 @@ public class FileTableUtils {
 	 *         null
 	 */
 	public static FileTableContent[] getDirectoryList(File file, SortType sortType, int direction, String filter, boolean useRegex, IProgressMonitor monitor) {
-		System.out.println("getting directory list for " + file.getName());
 		File[] list = null;
 		if (filter == null || filter.equals("*") || Pattern.matches("^\\s*$", filter)) {
 			list = file.listFiles();
@@ -163,7 +162,6 @@ public class FileTableUtils {
 	}
 
 	public static int getDirectoryListCount(File file, SortType sortType, int direction, String filter, boolean useRegex, IProgressMonitor monitor) {
-		System.out.println("getting directory list count for " + file.getName());
 		File[] list = null;
 		if (filter == null || filter.equals("*") || Pattern.matches("^\\s*$", filter)) {
 			list = file.listFiles();

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableUtils.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableUtils.java
@@ -14,6 +14,11 @@ import org.dawnsci.fileviewer.Utils.SortDirection;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 public class FileTableUtils {
+	
+	private FileTableUtils() {
+		
+	}
+	
 	/**
 	 * Sorts files lexicographically by name.
 	 * 
@@ -71,11 +76,6 @@ public class FileTableUtils {
 	}
 
 	public static int compareFiles(FileTableContent a, FileTableContent b, SortType sortType, SortDirection direction) {
-		// boolean aIsDir = a.isDirectory();
-		// boolean bIsDir = b.isDirectory();
-		// if (aIsDir && ! bIsDir) return -1;
-		// if (bIsDir && ! aIsDir) return 1;
-
 		// sort case-sensitive files in a case-insensitive manner
 		int compare = 0;
 		switch (sortType) {
@@ -97,7 +97,8 @@ public class FileTableUtils {
 			compare = sizea < sizeb ? -1 : 1;
 			break;
 		case TYPE:
-			String typea = a.getFileType(), typeb = b.getFileType();
+			String typea = a.getFileType();
+			String typeb = b.getFileType();
 			compare = typea.compareToIgnoreCase(typeb);
 			if (compare == 0)
 				compare = typea.compareTo(typeb);
@@ -108,7 +109,8 @@ public class FileTableUtils {
 			compare = date1.compareTo(date2);
 			break;
 		case SCAN:
-			String scana = a.getFileScanCmd(), scanb = b.getFileScanCmd();
+			String scana = a.getFileScanCmd();
+			String scanb = b.getFileScanCmd();
 			compare = scana.compareToIgnoreCase(scanb);
 			if (compare == 0)
 				compare = scana.compareTo(scanb);
@@ -167,7 +169,7 @@ public class FileTableUtils {
 		return contentList;
 	}
 
-	public static int getDirectoryListCount(File file, String filter, boolean useRegex, IProgressMonitor monitor) {
+	public static int getDirectoryListCount(File file, String filter, boolean useRegex) {
 		File[] list = null;
 		if (filter == null || "*".equals(filter) || Pattern.matches("^\\s*$", filter)) {
 			list = file.listFiles();

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableViewerComparator.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/FileTableViewerComparator.java
@@ -11,6 +11,7 @@ package org.dawnsci.fileviewer.table;
 import java.io.File;
 
 import org.dawnsci.fileviewer.FileViewer;
+import org.dawnsci.fileviewer.Utils.SortDirection;
 import org.dawnsci.fileviewer.Utils.SortType;
 import org.eclipse.jface.viewers.ColumnViewer;
 import org.eclipse.jface.viewers.TableViewerColumn;
@@ -28,11 +29,7 @@ import org.eclipse.swt.widgets.Table;
  */
 public class FileTableViewerComparator {
 
-	public static final int ASC = 1;
-	public static final int NONE = 0;
-	public static final int DESC = -1;
-
-	private int direction = 0;
+	private SortDirection direction = SortDirection.NONE;
 	private TableViewerColumn column;
 	private ColumnViewer viewer;
 	private int index;
@@ -54,48 +51,35 @@ public class FileTableViewerComparator {
 		return new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
-				int tdirection = FileTableViewerComparator.this.direction;
-				if (tdirection == ASC || tdirection == NONE) {
-					setSorter(FileTableViewerComparator.this, DESC);
-				} else if (tdirection == DESC) {
-					setSorter(FileTableViewerComparator.this, ASC);
+				SortDirection tdirection = FileTableViewerComparator.this.direction;
+				if (tdirection == SortDirection.ASC || tdirection == SortDirection.NONE) {
+					setSorter(FileTableViewerComparator.this, SortDirection.DESC);
+				} else if (tdirection == SortDirection.DESC) {
+					setSorter(FileTableViewerComparator.this, SortDirection.ASC);
 				}
 			}
 		};
 	}
 
-	private void setSorter(FileTableViewerComparator sorter, int direction) {
+	private void setSorter(FileTableViewerComparator sorter, SortDirection direction) {
 		Table columnParent = column.getColumn().getParent();
 		// Re sort the file[] array
 		try {
-			tableExplorer.setSortType(getSortTypeByIdx(index));
+			tableExplorer.setSortType(SortType.values()[index]);
 			File dir = fileViewer.getCurrentDirectory();
 			tableExplorer.workerUpdate(dir, true, tableExplorer.getSortType(), direction);
 		} finally {
-			if (direction == NONE) {
+			if (direction == SortDirection.NONE) {
 				columnParent.setSortColumn(null);
 				columnParent.setSortDirection(SWT.NONE);
 				viewer.setComparator(null);
 			} else {
 				columnParent.setSortColumn(column.getColumn());
 				sorter.direction = direction;
-				columnParent.setSortDirection(direction == ASC ? SWT.DOWN : SWT.UP);
+				columnParent.setSortDirection(direction == SortDirection.ASC ? SWT.DOWN : SWT.UP);
 				viewer.refresh();
 			}
 		}
 	}
 
-	private SortType getSortTypeByIdx(int i) {
-		if (i == 0)
-			return SortType.NAME;
-		else if (i == 1)
-			return SortType.SIZE;
-		else if (i == 2)
-			return SortType.TYPE;
-		else if (i == 3)
-			return SortType.DATE;
-		else if (i == 4)
-			return SortType.SCAN;
-		return null;
-	}
 }

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/RetrieveFileListJob.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/RetrieveFileListJob.java
@@ -10,7 +10,6 @@ package org.dawnsci.fileviewer.table;
 
 import java.io.File;
 
-import org.dawnsci.fileviewer.Utils;
 import org.dawnsci.fileviewer.Utils.SortType;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -18,31 +17,44 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 
 public class RetrieveFileListJob extends Job {
-	private File[] dirList;
-	private File workerStateDir;
-	private SortType sortType;
-	private int direction;
-	private String filter;
-	private boolean useRegex;
+	private FileTableContent[] dirList;
+	private int dirListCount;
+	final private File workerStateDir;
+	final private SortType sortType;
+	final private int direction;
+	final private String filter;
+	final private boolean useRegex;
+	final private boolean quick;
 	
-	public RetrieveFileListJob(File workerStateDir, SortType sortType, int direction, String filter, boolean useRegex) {
+	public RetrieveFileListJob(File workerStateDir, SortType sortType, int direction, String filter, boolean useRegex, boolean quick) {
 		super("Retrieving file list..");
 		this.workerStateDir = workerStateDir;
 		this.sortType = sortType;
 		this.direction = direction;
 		this.filter = filter;
 		this.useRegex = useRegex;
+		this.quick = quick;
 	}
 
 	@Override
 	protected IStatus run(IProgressMonitor monitor) {
-		dirList = Utils.getDirectoryList(workerStateDir, sortType, direction, filter, useRegex, monitor);
+		if (quick) {
+			dirListCount = FileTableUtils.getDirectoryListCount(workerStateDir, sortType, direction, filter, useRegex, monitor);
+		} else {
+			dirList = FileTableUtils.getDirectoryList(workerStateDir, sortType, direction, filter, useRegex, monitor);
+			dirListCount = dirList.length;
+		}
 		if (dirList == null)
 			return Status.CANCEL_STATUS;
 		return Status.OK_STATUS;
 	}
 
-	public File[] getDirList() {
+	public FileTableContent[] getDirList() {
 		return dirList;
 	}
+	
+	public int getDirListCount() {
+		return dirListCount;
+	}
+	
 }

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/RetrieveFileListJob.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/RetrieveFileListJob.java
@@ -11,6 +11,7 @@ package org.dawnsci.fileviewer.table;
 import java.io.File;
 
 import org.dawnsci.fileviewer.Utils.SortType;
+import org.dawnsci.fileviewer.Utils.SortDirection;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -19,14 +20,14 @@ import org.eclipse.core.runtime.jobs.Job;
 public class RetrieveFileListJob extends Job {
 	private FileTableContent[] dirList;
 	private int dirListCount;
-	final private File workerStateDir;
-	final private SortType sortType;
-	final private int direction;
-	final private String filter;
-	final private boolean useRegex;
-	final private boolean quick;
+	private final File workerStateDir;
+	private final SortType sortType;
+	private final SortDirection direction;
+	private final String filter;
+	private final boolean useRegex;
+	private final boolean quick;
 	
-	public RetrieveFileListJob(File workerStateDir, SortType sortType, int direction, String filter, boolean useRegex, boolean quick) {
+	public RetrieveFileListJob(File workerStateDir, SortType sortType, SortDirection direction, String filter, boolean useRegex, boolean quick) {
 		super("Retrieving file list..");
 		this.workerStateDir = workerStateDir;
 		this.sortType = sortType;
@@ -39,7 +40,7 @@ public class RetrieveFileListJob extends Job {
 	@Override
 	protected IStatus run(IProgressMonitor monitor) {
 		if (quick) {
-			dirListCount = FileTableUtils.getDirectoryListCount(workerStateDir, sortType, direction, filter, useRegex, monitor);
+			dirListCount = FileTableUtils.getDirectoryListCount(workerStateDir, filter, useRegex, monitor);
 		} else {
 			dirList = FileTableUtils.getDirectoryList(workerStateDir, sortType, direction, filter, useRegex, monitor);
 			dirListCount = dirList.length;

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/RetrieveFileListJob.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/RetrieveFileListJob.java
@@ -42,7 +42,7 @@ public class RetrieveFileListJob extends Job {
 		if (quick) {
 			dirListCount = FileTableUtils.getDirectoryListCount(workerStateDir, filter, useRegex);
 		} else {
-			dirList = FileTableUtils.getDirectoryList(workerStateDir, sortType, direction, filter, useRegex, monitor);
+			dirList = FileTableUtils.getDirectoryList(workerStateDir, sortType, direction, filter, useRegex);
 			dirListCount = dirList.length;
 		}
 		if (dirList == null)

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/RetrieveFileListJob.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/table/RetrieveFileListJob.java
@@ -40,7 +40,7 @@ public class RetrieveFileListJob extends Job {
 	@Override
 	protected IStatus run(IProgressMonitor monitor) {
 		if (quick) {
-			dirListCount = FileTableUtils.getDirectoryListCount(workerStateDir, filter, useRegex, monitor);
+			dirListCount = FileTableUtils.getDirectoryListCount(workerStateDir, filter, useRegex);
 		} else {
 			dirList = FileTableUtils.getDirectoryList(workerStateDir, sortType, direction, filter, useRegex, monitor);
 			dirListCount = dirList.length;

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/tree/TreeUtils.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/tree/TreeUtils.java
@@ -12,19 +12,26 @@
 package org.dawnsci.fileviewer.tree;
 
 import java.io.File;
+import java.util.Arrays;
 
 import org.dawnsci.fileviewer.FileViewer;
 import org.dawnsci.fileviewer.FileViewerConstants;
 import org.dawnsci.fileviewer.IconCache;
-import org.dawnsci.fileviewer.Utils;
-import org.dawnsci.fileviewer.Utils.SortType;
-import org.dawnsci.fileviewer.table.FileTableViewerComparator;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
 
 public class TreeUtils {
 
+	public static int compareFiles(File a, File b) {
+		// sort case-sensitive files in a case-insensitive manner
+		int compare = 0;
+			compare = a.getName().compareToIgnoreCase(b.getName());
+			if (compare == 0)
+				compare = a.getName().compareTo(b.getName());
+		return compare;
+	}
+	
 	/**
 	 * Traverse the entire tree and update only what has changed.
 	 * 
@@ -44,7 +51,7 @@ public class TreeUtils {
 				continue;
 			}
 			final File masterFile = masterFiles[masterIndex];
-			int compare = Utils.compareFiles(masterFile, itemFile, SortType.NAME, FileTableViewerComparator.ASC);
+			int compare = compareFiles(masterFile, itemFile);
 			if (compare == 0) {
 				// same file, update it
 				treeRefreshItem(viewer, item, false, iconCache);
@@ -104,7 +111,9 @@ public class TreeUtils {
 		/* Get directory listing */
 		File[] subFiles = null;
 		if (dir != null) {
-			subFiles = Utils.getDirectoryList(dir, SortType.NAME, FileTableViewerComparator.ASC, null, true);
+			//subFiles = Utils.getDirectoryList(null, SortType.NAME, FileTableViewerComparator.ASC, null, true);
+			subFiles = dir.listFiles();
+			Arrays.sort(subFiles);
 		}
 		if (subFiles == null || subFiles.length == 0) {
 			/* Error or no contents */
@@ -133,7 +142,7 @@ public class TreeUtils {
 				item.dispose();
 				continue;
 			}
-			int compare = Utils.compareFiles(masterFile, itemFile, SortType.NAME, FileTableViewerComparator.ASC);
+			int compare = compareFiles(masterFile, itemFile);
 			if (compare == 0) {
 				// same file, update it
 				treeRefreshItem(viewer, item, false, iconCache);

--- a/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/tree/TreeUtils.java
+++ b/org.dawnsci.fileviewer/src/org/dawnsci/fileviewer/tree/TreeUtils.java
@@ -111,7 +111,6 @@ public class TreeUtils {
 		/* Get directory listing */
 		File[] subFiles = null;
 		if (dir != null) {
-			//subFiles = Utils.getDirectoryList(null, SortType.NAME, FileTableViewerComparator.ASC, null, true);
 			subFiles = dir.listFiles();
 			Arrays.sort(subFiles);
 		}


### PR DESCRIPTION
* FileViewer previously hanged when fetching the scan_command from HDF5 files with vast amounts of groups and/or datasets.
* Some refactoring
* File information is read within LazyContentProvider instead of ColumnLabelProvider