### PR TITLE
[DAQ-756] Remove MappedDataView's dependency on scanning service holder

### DIFF
--- a/org.dawnsci.mapping.ui/META-INF/MANIFEST.MF
+++ b/org.dawnsci.mapping.ui/META-INF/MANIFEST.MF
@@ -19,8 +19,7 @@ Require-Bundle: org.eclipse.ui,
  org.dawnsci.slicing.tools;bundle-version="1.0.0",
  org.eclipse.dawnsci.nexus,
  org.dawnsci.common.widgets,
- org.eclipse.scanning.api;bundle-version="1.0.0",
- org.eclipse.scanning.device.ui
+ org.eclipse.scanning.api;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/*.xml

--- a/org.dawnsci.mapping.ui/OSGI-INF/localServiceManager.xml
+++ b/org.dawnsci.mapping.ui/OSGI-INF/localServiceManager.xml
@@ -6,4 +6,5 @@
    <reference bind="setRemoteDatasetService" cardinality="1..1" interface="org.eclipse.dawnsci.analysis.api.io.IRemoteDatasetService" name="IRemoteDatasetService" policy="static"/>
    <reference bind="setNexusFactory" cardinality="1..1" interface="org.eclipse.dawnsci.nexus.INexusFileFactory" name="INexusFileFactory" policy="static"/>
    <reference bind="setEventAdmin" cardinality="1..1" interface="org.osgi.service.event.EventAdmin" name="EventAdmin" policy="static"/>
+   <reference bind="setMarshallerService" cardinality="1..1" interface="org.eclipse.dawnsci.analysis.api.persistence.IMarshallerService" name="IMarshallerService" policy="static"/>
 </scr:component>

--- a/org.dawnsci.mapping.ui/src/org/dawnsci/mapping/ui/LocalServiceManager.java
+++ b/org.dawnsci.mapping.ui/src/org/dawnsci/mapping/ui/LocalServiceManager.java
@@ -2,9 +2,9 @@ package org.dawnsci.mapping.ui;
 
 import org.eclipse.dawnsci.analysis.api.io.ILoaderService;
 import org.eclipse.dawnsci.analysis.api.io.IRemoteDatasetService;
+import org.eclipse.dawnsci.analysis.api.persistence.IMarshallerService;
 import org.eclipse.dawnsci.analysis.api.persistence.IPersistenceService;
 import org.eclipse.dawnsci.nexus.INexusFileFactory;
-import org.eclipse.scanning.api.event.IEventService;
 import org.osgi.service.event.EventAdmin;
 
 public class LocalServiceManager {
@@ -14,7 +14,8 @@ public class LocalServiceManager {
 	private static IRemoteDatasetService dservice;
 	private static INexusFileFactory nexusFactory;
 	private static EventAdmin eventAdmin;
-	
+	private static IMarshallerService marshallerService;
+
 	public static void setLoaderService(ILoaderService s) {
 		lservice = s;
 	}
@@ -53,6 +54,14 @@ public class LocalServiceManager {
 
 	public static void setEventAdmin(EventAdmin eventAdmin) {
 		LocalServiceManager.eventAdmin = eventAdmin;
+	}
+
+	public static IMarshallerService getMarshallerService() {
+		return marshallerService;
+	}
+
+	public static void setMarshallerService(IMarshallerService marshallerService) {
+		LocalServiceManager.marshallerService = marshallerService;
 	}
 	
 }

--- a/org.dawnsci.mapping.ui/src/org/dawnsci/mapping/ui/MappedDataView.java
+++ b/org.dawnsci.mapping.ui/src/org/dawnsci/mapping/ui/MappedDataView.java
@@ -54,7 +54,6 @@ import org.eclipse.scanning.api.event.scan.ScanEvent;
 import org.eclipse.scanning.api.event.status.Status;
 import org.eclipse.scanning.api.event.status.StatusBean;
 import org.eclipse.scanning.api.ui.CommandConstants;
-import org.eclipse.scanning.device.ui.ServiceHolder;
 import org.eclipse.swt.dnd.DND;
 import org.eclipse.swt.dnd.DropTarget;
 import org.eclipse.swt.dnd.DropTargetAdapter;
@@ -479,7 +478,7 @@ public class MappedDataView extends ViewPart {
 			try {
 				final String savedState = memento.getString(getSavedStateKey());
 				if (savedState != null) {
-					initialState = ServiceHolder.getMarshallerService().unmarshal(savedState,
+					initialState = LocalServiceManager.getMarshallerService().unmarshal(savedState,
 							MappedDataViewState.class);
 				}
 			} catch (Exception e) {
@@ -502,7 +501,7 @@ public class MappedDataView extends ViewPart {
 					state.setFilesInView(filesInView);
 					logger.info("Saving view state: {}", state);
 
-					final String stateString = ServiceHolder.getMarshallerService().marshal(state);
+					final String stateString = LocalServiceManager.getMarshallerService().marshal(state);
 					memento.putString(getSavedStateKey(), stateString);
 				}
 			} catch (Exception e) {


### PR DESCRIPTION
LocalServiceManager needs an IMarshallerService to persist its state
(the list of files to show when the client starts). Instead of
getting this from ServiceHolder in a scanning package, add the
marshaller service to the UI's own LocalServiceManager.