### PR TITLE
Update to more recent version of launchbar

### DIFF
--- a/org.dawnsci.dde.feature/feature.xml
+++ b/org.dawnsci.dde.feature/feature.xml
@@ -143,4 +143,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.launchbar.ui.controls"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/org.dawnsci.dde.ui/META-INF/MANIFEST.MF
+++ b/org.dawnsci.dde.ui/META-INF/MANIFEST.MF
@@ -19,6 +19,7 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.8.2",
  org.eclipse.e4.ui.model.workbench;bundle-version="1.1.100",
  org.eclipse.launchbar.ui;bundle-version="1.0.1",
  org.dawb.common.ui,
- org.eclipse.jdt.launching
+ org.eclipse.jdt.launching,
+ org.eclipse.launchbar.ui.controls
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/org.dawnsci.dde.ui/src/org/dawnsci/dde/ui/internal/LaunchBarPerspectiveHandler.java
+++ b/org.dawnsci.dde.ui/src/org/dawnsci/dde/ui/internal/LaunchBarPerspectiveHandler.java
@@ -30,7 +30,7 @@ import org.eclipse.e4.ui.model.application.ui.menu.MToolControl;
 import org.eclipse.e4.ui.workbench.UIEvents;
 import org.eclipse.e4.ui.workbench.UIEvents.EventTags;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
-import org.eclipse.launchbar.ui.internal.controls.LaunchBarControl;
+import org.eclipse.launchbar.ui.controls.internal.LaunchBarControl;
 import org.eclipse.swt.widgets.Widget;
 import org.osgi.service.event.Event;
 


### PR DESCRIPTION
Requires [launchbar#5](https://github.com/Itema-as/org.eclipse.launchbar/pull/5) or [dawn-update branch](https://github.com/PeterC-DLS/org.eclipse.launchbar/tree/dawn-update)