### PR TITLE
SCI-6499: DataVis -> remove title when switching from 2D to 1D

### DIFF
--- a/org.dawnsci.datavis.model/src/org/dawnsci/datavis/model/PlotController.java
+++ b/org.dawnsci.datavis.model/src/org/dawnsci/datavis/model/PlotController.java
@@ -250,7 +250,12 @@ public class PlotController implements IPlotController {
 			localMode = currentMode;
 		} else if (plotObject == null) {
 			plotObject = getPlottableObject();
-			if (selected) currentMode = plotObject.getPlotMode();
+			if (selected) {
+				currentMode = plotObject.getPlotMode();
+				if (currentMode != localMode) {
+					system.setTitle("");
+				}
+			}
 			localMode = plotObject.getPlotMode();
 		}
 		dOption.getPlottableObject().getNDimensions().addSliceListener(sliceListener);


### PR DESCRIPTION
Until now, the title of the 2D plot would remain if the 1D dataset had not been loaded before.